### PR TITLE
Checkpoints to save progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ obj
 bin
 highscore.txt
 .suo
+checkpoint.txt


### PR DESCRIPTION
I've tested it with all 5 levels all the way through and this simple checkpoint system that I've made works well. I used the same paradigm as the high score file.  The program makes a simple checkpoint.txt (in the same folder as the highscore.txt) every time they get to a new level, and it reads the checkpoint file when the game is first started.  If the user wants to they can delete the checkpoint file and the game will reset back to level 1.  The checkpoint file is gitignored and the game will start fine without one.  It doesnt save your score at the checkpoint so its not strictly a continue but it generally saves your progress so you dont get set all the way back to square one which makes it implicitly rewarding to beat the whole game in one sitting (because you will have more levels contributing to your score).  This approach seemed like the simplest solution for the user to lose all progress if their computer dies or their cat steps on the escape key.  I hope to add many more levels for a more advanced campaign and dont want to lose progress.   This will also let anyone to easily test their later levels during development.